### PR TITLE
Fix context.Copy() race condition

### DIFF
--- a/context.go
+++ b/context.go
@@ -82,6 +82,10 @@ func (c *Context) Copy() *Context {
 	cp.Writer = &cp.writermem
 	cp.index = abortIndex
 	cp.handlers = nil
+        cp.Keys = map[string]interface{}{}
+        for k, v := range c.Keys {
+                cp.Keys[k] = v
+        }
 	return &cp
 }
 


### PR DESCRIPTION
This PR aims to point an existing race condition with the gin.Context and propose a solution.

The gin.Context stores keys in a `map[string]interface{}`. The function gin.Context.Copy()  (context.go:79) is supposed to give a thread safe copy of the initial gin.Context.

Instead of making a proper copy of the context.Keys, it copies the reference to the map. This creates a race condition whenever the map context.Keys is accessed by concurrent go-routines.

With the following script you will get the raise condition instantly. The fix in the PR will solve it.
```
package main

import (
        "github.com/gin-gonic/gin"
        "math/rand"
)

func main() {

        r := gin.Default()
        r.GET("/", func(ctx *gin.Context) {
                ctx.Set("1", 0)
                ctx.Set("2", 0)

                // Sending a copy of the gin.Context to two separate routines
                go ReadWriteKeys(ctx.Copy())
                go ReadWriteKeys(ctx.Copy())
        })
        r.Run(":8080")
}

func ReadWriteKeys(ctx *gin.Context) {
        for {
                ctx.Set("1", rand.Int())
                ctx.Set("2", ctx.Value("1"))
        }
}
```
